### PR TITLE
feat: add order retrieval api and refresh UI graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ npm start
 
 - Visit `http://localhost:3000` for the marketing website.
 - Visit `http://localhost:3000/app` for the web app where you can place a mock order.
+- A simple REST API is available at `http://localhost:3000/api/orders` to create and
+  view orders.
 
 ## Testing
-No automated tests are included yet:
+Run the Jest test suite:
 ```bash
 npm test
 ```

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -54,6 +54,7 @@ function OrderForm() {
 
   return (
     <div className="bg-white shadow-md rounded p-6">
+      <img className="w-full rounded mb-4" src="https://images.unsplash.com/photo-1581091226825-11c0d31d7bbb?auto=format&fit=crop&w=1350&q=80" alt="LPG cylinders" />
       <h1 className="text-2xl font-bold mb-4 text-purple-700">Order LPG Refill</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <input className="w-full p-2 border rounded" name="name" placeholder="Name" value={form.name} onChange={handleChange} required />

--- a/public/website/index.html
+++ b/public/website/index.html
@@ -14,7 +14,7 @@
     </div>
   </header>
   <main class="max-w-4xl mx-auto p-6">
-    <img class="w-full rounded shadow mb-6" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1350&q=80" alt="Gas cylinders" />
+    <img class="w-full rounded shadow mb-6" src="https://images.unsplash.com/photo-1611689406290-d69d4805d847?auto=format&fit=crop&w=1350&q=80" alt="Modern gas delivery truck" />
     <section class="mb-6">
       <h2 class="text-2xl font-semibold text-purple-700 mb-2">Convenient Refills</h2>
       <p>Order online and have your LPG cylinders collected, refilled, and delivered back to your doorstep.</p>

--- a/server.js
+++ b/server.js
@@ -61,6 +61,29 @@ app.post('/api/orders', [
   }
 });
 
+app.get('/api/orders', async (req, res) => {
+  try {
+    const orders = await Order.find().sort({ createdAt: -1 });
+    return res.json(orders);
+  } catch (err) {
+    logger.error(err);
+    return res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.get('/api/orders/:id', async (req, res) => {
+  try {
+    const order = await Order.findById(req.params.id);
+    if (!order) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
+    return res.json(order);
+  } catch (err) {
+    logger.error(err);
+    return res.status(500).json({ error: 'Server error' });
+  }
+});
+
 const PORT = process.env.PORT || 3000;
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/basagas';
 

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -6,6 +6,8 @@ jest.mock('../models/Order');
 
 beforeEach(() => {
   Order.create.mockReset();
+  Order.find.mockReset();
+  Order.findById.mockReset();
 });
 
 describe('POST /api/orders', () => {
@@ -40,5 +42,32 @@ describe('POST /api/orders', () => {
         paymentType: 'subscription'
       });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/orders', () => {
+  it('returns list of orders', async () => {
+    Order.find.mockReturnValue({
+      sort: jest.fn().mockResolvedValue([{ id: '1' }])
+    });
+    const res = await request(app).get('/api/orders');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: '1' }]);
+    expect(Order.find).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/orders/:id', () => {
+  it('returns an order by id', async () => {
+    Order.findById.mockResolvedValue({ id: '1' });
+    const res = await request(app).get('/api/orders/1');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('1');
+  });
+
+  it('returns 404 when not found', async () => {
+    Order.findById.mockResolvedValue(null);
+    const res = await request(app).get('/api/orders/999');
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- add GET endpoints to retrieve LPG orders by id or list
- refresh website and app with updated hero images
- document API and add Jest coverage for new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b99cdee18832e9101684b2418dda5